### PR TITLE
fix: resolve ESLint errors (TS in astro scripts, unused import)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,13 @@ module.exports = {
       },
       rules: {},
     },
+    {
+      // Client-side `<script>` blocks are extracted to virtual `*.astro/*.js`
+      // files. Astro compiles them as TypeScript, so lint them with the TS
+      // parser — otherwise TS-only syntax (casts, non-null assertions) errors.
+      files: ["**/*.astro/*.js", "*.astro/*.js"],
+      parser: "@typescript-eslint/parser",
+      rules: {},
+    },
   ],
 };

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -2,7 +2,6 @@
 import type { GetStaticPaths } from "astro";
 import { getCollection, render } from "astro:content";
 import BaseLayout from "@layouts/BaseLayout.astro";
-import getSortedPosts from "@utils/getSortedPosts";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection("blog");


### PR DESCRIPTION
## What

Fixes the two pre-existing ESLint errors noted as out-of-scope in #7:

1. **`contact.astro` — `Parsing error: Unexpected token as`**
   `eslint-plugin-astro` extracts each client `<script>` into a virtual `*.astro/*.js` file and lints it with the default (JS) parser. Astro compiles those scripts as **TypeScript**, so TS-only syntax (`as` casts, `!` non-null assertions) tripped the parser. Added an ESLint override pointing the virtual script files at `@typescript-eslint/parser`.

2. **`blog/[slug].astro` — `getSortedPosts is defined but never used`**
   Removed the dead import (the page uses `getCollection` directly).

## Why

The repo runs Prettier in lint-staged but not ESLint, so `bun run lint` had been failing silently. Both issues now resolved without touching application logic.

## Verification

- ✅ `bun run lint` — clean (exit 0)
- ✅ `bun run format:check` — clean
- ✅ `bun run build` — 21 pages built