### PR TITLE
fix: clear Astro content-layer cache before build (stale deleted posts)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "framework": "astro",
-  "buildCommand": "bun run build",
+  "buildCommand": "rm -rf .astro node_modules/.astro && bun run build",
   "outputDirectory": "dist",
   "installCommand": "bash scripts/vercel-install.sh"
 }


### PR DESCRIPTION
## Problem

After #9 deleted the AstroPaper demo posts, the production deploy (eec8073) **still served all 12 demo posts** — and so did the deployment URL directly (`hserra-408d64edq…/blog/`). But the source for that commit has only `.gitkeep`, and **local builds of the same source produce the correct empty-state.**

## Root cause

Vercel restores Astro's content-layer data store (`.astro/` / `node_modules/.astro/`) from its build cache. On a restored store in CI, Astro's `glob()` loader doesn't prune entries whose source files were deleted — so the build re-emits pages for posts that no longer exist on disk. Local builds were clean because the store re-synced there.

## Fix

Clear the content-layer caches before each build, forcing the blog collection to re-sync from the actual filesystem:

```
"buildCommand": "rm -rf .astro node_modules/.astro && bun run build"
```

Self-heals future content deletions/renames too.

## Verification

Verifying on this PR's preview deploy before merging to production (preview must show the empty-state, not demo posts).